### PR TITLE
Use `alloc` instead of `allocUnsafe`, fix #35

### DIFF
--- a/lib/crypto/index.js
+++ b/lib/crypto/index.js
@@ -99,7 +99,7 @@ function megaDecrypt (key, options = {}) {
 export { megaEncrypt, megaDecrypt }
 
 function unmergeKeyMac (key) {
-  const newKey = Buffer.allocUnsafe(32)
+  const newKey = Buffer.alloc(32)
   key.copy(newKey)
 
   for (let i = 0; i < 16; i++) {
@@ -110,7 +110,7 @@ function unmergeKeyMac (key) {
 }
 
 function mergeKeyMac (key, mac) {
-  const newKey = Buffer.allocUnsafe(32)
+  const newKey = Buffer.alloc(32)
   key.copy(newKey)
   mac.copy(newKey, 24)
 


### PR DESCRIPTION
If key is smaller than 32 bytes using allocUnsafe could add some random bytes at the end and make the result invalid