### PR TITLE
Removed noAssert parameter from buf.readInt

### DIFF
--- a/lib/crypto/aes.js
+++ b/lib/crypto/aes.js
@@ -52,7 +52,12 @@ class AES {
   stringhash (buffer) {
     const h32 = [0, 0, 0, 0]
     for (let i = 0; i < buffer.length; i += 4) {
-      h32[(i / 4) & 3] ^= buffer.readInt32BE(i, true)
+      if (buffer.length - i < 4) {
+        const len = buffer.length - i;
+        h32[i / 4 & 3] ^= buffer.readIntBE(i, len) << (4 - len) * 8;
+      } else {
+        h32[i / 4 & 3] ^= buffer.readInt32BE(i);
+      }
     }
 
     let hash = Buffer.allocUnsafe(16)

--- a/lib/crypto/aes.js
+++ b/lib/crypto/aes.js
@@ -53,10 +53,10 @@ class AES {
     const h32 = [0, 0, 0, 0]
     for (let i = 0; i < buffer.length; i += 4) {
       if (buffer.length - i < 4) {
-        const len = buffer.length - i;
-        h32[i / 4 & 3] ^= buffer.readIntBE(i, len) << (4 - len) * 8;
+        const len = buffer.length - i
+        h32[i / 4 & 3] ^= buffer.readIntBE(i, len) << (4 - len) * 8
       } else {
-        h32[i / 4 & 3] ^= buffer.readInt32BE(i);
+        h32[i / 4 & 3] ^= buffer.readInt32BE(i)
       }
     }
 


### PR DESCRIPTION
Node v10 has removed the noAssert parameter from every Buffer.read* function, using it results with error.