### PR TITLE
Fixes issue 58

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -75,9 +75,12 @@ class File extends EventEmitter {
     if (!this.key) return this
     at = d64(at)
     getCipher(this.key).decryptCBC(at)
-    at = File.unpackAttributes(at)
 
-    this.parseAttributes(at)
+    const unpackedAttribtes = File.unpackAttributes(at)
+    if (unpackedAttribtes) {
+      this.parseAttributes(unpackedAttribtes)
+    }
+
     return this
   }
 
@@ -144,6 +147,9 @@ class File extends EventEmitter {
         }
 
         this.loadMetadata(aes, folder)
+        if (this.key && !this.attributes) {
+          return cb(Error('Attributes could not be decrypted with provided key.'))
+        }
 
         if (this.loadedFile) {
           const loadedNode = filesMap[this.loadedFile]
@@ -157,11 +163,12 @@ class File extends EventEmitter {
         }
       } else {
         this.size = response.s
-        try {
-          this.decryptAttributes(response.at)
-        } catch (err) {
-          return cb(err)
+        this.decryptAttributes(response.at)
+
+        if (this.key && !this.attributes) {
+          return cb(Error('Attributes could not be decrypted with provided key.'))
         }
+
         cb(null, this)
       }
     })
@@ -401,11 +408,11 @@ class File extends EventEmitter {
     while (end < at.length && at.readUInt8(end)) end++
 
     at = at.slice(0, end).toString()
-    if (at.substr(0, 6) !== 'MEGA{"') {
-      throw Error('Attributes could not be decrypted with provided key.')
-    }
+    if (at.substr(0, 6) !== 'MEGA{"') return
 
-    return JSON.parse(at.substr(4))
+    try {
+      return JSON.parse(at.substr(4))
+    } catch (e) {}
   }
 }
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -1,27 +1,10 @@
-import {
-  e64,
-  d64,
-  AES,
-  formatKey,
-  getCipher,
-  megaDecrypt
-} from './crypto'
+import { e64, d64, AES, formatKey, getCipher, megaDecrypt } from './crypto'
 import CombinedStream from 'combined-stream'
-import {
-  API
-} from './api'
-import {
-  EventEmitter
-} from 'events'
-import {
-  parse
-} from 'url'
-import {
-  streamToCb
-} from './util'
-import {
-  PassThrough
-} from 'stream'
+import { API } from './api'
+import { EventEmitter } from 'events'
+import { parse } from 'url'
+import { streamToCb } from './util'
+import { PassThrough } from 'stream'
 import StreamSkip from 'stream-skip'
 let notLoggedApi
 
@@ -98,6 +81,7 @@ class File extends EventEmitter {
       }
     }
 
+    // todo: nodeId version ('n')
     const req = this.directory ? {
       a: 'f',
       c: 1,
@@ -109,7 +93,7 @@ class File extends EventEmitter {
     } : {
       a: 'g',
       p: this.downloadId
-    } // todo: nodeId version ('n')
+    }
 
     this.api.request(req, (err, response) => {
       if (err) return cb(err)
@@ -355,16 +339,16 @@ class File extends EventEmitter {
 
     // Supported formats:
     // Old format:
-    // https://mega.nz/#!file_handker
-    // https://mega.nz/#!file_handker!file_key
-    // https://mega.nz/#F!folder_handker
-    // https://mega.nz/#F!folder_handker!folder_key
-    // https://mega.nz/#F!folder_handker!folder_key!file_handle
+    // https://mega.nz/#!file_handler
+    // https://mega.nz/#!file_handler!file_key
+    // https://mega.nz/#F!folder_handler
+    // https://mega.nz/#F!folder_handler!folder_key
+    // https://mega.nz/#F!folder_handler!folder_key!file_handler
     // New format (2020):
-    // https://mega.nz/file/file_handker
-    // https://mega.nz/file/file_handker#file_key
-    // https://mega.nz/folder/folder_handker
-    // https://mega.nz/folder/folder_handker#folder_key
+    // https://mega.nz/file/file_handler
+    // https://mega.nz/file/file_handler#file_key
+    // https://mega.nz/folder/folder_handler
+    // https://mega.nz/folder/folder_handler#folder_key
 
     const url = parse(opt)
     if (url.hostname !== 'mega.nz' && url.hostname !== 'mega.co.nz') { throw Error('Invalid URL: wrong hostname') }

--- a/lib/file.js
+++ b/lib/file.js
@@ -324,9 +324,12 @@ class File extends EventEmitter {
       }
     }
 
-    let url = `https://mega.nz/#${this.directory ? 'F' : ''}!${this.downloadId}`
-    if (!options.noKey && this.key) url += `!${e64(this.key)}`
-    if (!options.noKey && this.loadedFile) url += `!${this.loadedFile}`
+    let url = `https://mega.nz/${this.directory ? 'folder' : 'file'}/${this.downloadId}`
+    if (!options.noKey && this.key) url += `#${e64(this.key)}`
+    if (!options.noKey && this.loadedFile) {
+      // TODO: check if the loaded file is, in fact, a folder
+      url += `/file/${this.loadedFile}`
+    }
 
     cb(null, url)
   }

--- a/lib/mutable-file.js
+++ b/lib/mutable-file.js
@@ -541,8 +541,8 @@ class MutableFile extends File {
     this.api.request({a: 'l', n: this.nodeId}, (err, id) => {
       if (err) return cb(err)
 
-      let url = `https://mega.nz/#${folderKey ? 'F' : ''}!${id}`
-      if (!options.noKey && this.key) url += `!${e64(folderKey || this.key)}`
+      let url = `https://mega.nz/${folderKey ? 'folder' : 'file'}/${id}`
+      if (!options.noKey && this.key) url += `#${e64(folderKey || this.key)}`
 
       cb(null, url)
     })

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -164,15 +164,7 @@ class Storage extends EventEmitter {
           const file = this.files[o.n]
           if (file) {
             file.timestamp = o.ts
-            try {
-              file.decryptAttributes(o.at)
-            } catch (err) {
-              // Do not emit the file, instead emit a "file-decrypt-error"
-              // so it can be handled seamlessly
-              err.file = file
-              this.emit('file-decrypt-error', err)
-              return
-            }
+            file.decryptAttributes(o.at)
             file.emit('update')
             this.emit('update', file)
           }
@@ -230,9 +222,13 @@ class Storage extends EventEmitter {
       }
       if (f.p) {
         let parent = this.files[f.p]
-        if (!parent.children) parent.children = []
-        parent.children.push(file)
-        file.parent = parent
+
+        // Issue 58: some accounts have orphan files
+        if (parent) {
+          if (!parent.children) parent.children = []
+          parent.children.push(file)
+          file.parent = parent
+        }
       }
     }
     return this.files[f.h]

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -12,6 +12,7 @@ test.serial.before.cb(t => {
     unsafeCleanup: true
   }, (err, path, cleanupCallback) => {
     if (err) throw err
+
     const server = megamock({
       dataFolder: path,
       visualize: false
@@ -105,22 +106,7 @@ test.serial.cb('Should upload streams', t => {
   uploadStream.end(Buffer.alloc(1024 * 1024))
 })
 
-test.serial.cb('Should share files (old format)', t => {
-  const storage = t.context.storage
-  const server = t.context.server
-
-  const userFiles = server.state.users.get('jCf2Pc0pLCU').files
-  const file = storage.files[userFiles[0].h]
-
-  file.link((error, link) => {
-    if (error) throw error
-    t.is(link, 'https://mega.nz/#!AAAAAAAE!AAAAAAAAAACldyOdMzqeRgAAAAAAAAAApXcjnTM6nkY')
-    t.end()
-  })
-})
-
-// Skipped as mega-mock doesn't handle new url format yet
-test.serial.skip('Should share files (new format)', t => {
+test.serial.cb('Should share files', t => {
   const storage = t.context.storage
   const server = t.context.server
 
@@ -210,7 +196,7 @@ test.serial.cb('Should share folders', t => {
     key: Buffer.alloc(16)
   }, (error, link) => {
     if (error) throw error
-    t.is(link, 'https://mega.nz/#F!AAAAAAAG!AAAAAAAAAAAAAAAAAAAAAA')
+    t.is(link, 'https://mega.nz/folder/AAAAAAAG#AAAAAAAAAAAAAAAAAAAAAA')
     t.end()
   })
 })


### PR DESCRIPTION
I can't just remove attribute decoding verification: some applications rely on that. IIRC [direct-mega](https://github.com/qgustavor/direct-mega/) used this error to notify users when they provided a wrong key. I made it throw the same error if a shared file is loaded and its attributes can't be loaded.

Changes in storage.js:
- Avoid throwing when a parent of a node don't exist.

Changes in storage.js and file.js:
- `decryptAttributes` don't throw anymore, instead files with garbled attributes will have `attributes` property being `undefined`.

*Can someone review this code?*