### PR TITLE
Get the sharing link of files

### DIFF
--- a/lib/storage.mjs
+++ b/lib/storage.mjs
@@ -169,14 +169,14 @@ class Storage extends EventEmitter {
 
       response.f.forEach(file => {
         file = this._importFile(file)
-        file.shareId = response.ph.find(item => item.h == file.nodeId)?.ph
+        file.shareId = response.ph.find(item => item.h === file.nodeId)?.ph
         file.shared = !!file.shareId
 
         if (file.shared) {
           file.shareURL = `https://mega.nz/${file.directory ? 'folder' : 'file'}/${file.shareId}`
           if (file.key) file.shareURL += `#${e64(file.directory ? this.shareKeys[file.nodeId] : file.key)}`
         }
-      });
+      })
       cb(null, this.mounts)
     })
 

--- a/lib/storage.mjs
+++ b/lib/storage.mjs
@@ -167,7 +167,16 @@ class Storage extends EventEmitter {
         return shares
       }, {})
 
-      response.f.forEach(file => this._importFile(file))
+      response.f.forEach(file => {
+        file = this._importFile(file)
+        file.shareId = response.ph.find(item => item.h == file.nodeId)?.ph
+        file.shared = !!file.shareId
+
+        if (file.shared) {
+          file.shareURL = `https://mega.nz/${file.directory ? 'folder' : 'file'}/${file.shareId}`
+          if (file.key) file.shareURL += `#${e64(file.directory ? this.shareKeys[file.nodeId] : file.key)}`
+        }
+      });
       cb(null, this.mounts)
     })
 

--- a/lib/storage.mjs
+++ b/lib/storage.mjs
@@ -169,12 +169,16 @@ class Storage extends EventEmitter {
 
       response.f.forEach(file => {
         file = this._importFile(file)
-        file.shareId = response.ph.find(item => item.h === file.nodeId)?.ph
-        file.shared = !!file.shareId
 
-        if (file.shared) {
-          file.shareURL = `https://mega.nz/${file.directory ? 'folder' : 'file'}/${file.shareId}`
-          if (file.key) file.shareURL += `#${e64(file.directory ? this.shareKeys[file.nodeId] : file.key)}`
+        // If the account have no links "ph" is undefined.
+        if (response.ph !== undefined) {
+          file.shareId = response.ph.find(item => item.h === file.nodeId)?.ph
+          file.shared = !!file.shareId
+
+          if (file.shared) {
+            file.shareURL = `https://mega.nz/${file.directory ? 'folder' : 'file'}/${file.shareId}`
+            if (file.key) file.shareURL += `#${e64(file.directory ? this.shareKeys[file.nodeId] : file.key)}`
+          }
         }
       })
       cb(null, this.mounts)


### PR DESCRIPTION
When listing files, MEGA introduces a property named `ph` which contains the list of shared links "unique identifiers".
This determines whether a file is shared and its sharing link when it is imported.