### PR TITLE
Better error handling in API

### DIFF
--- a/lib/api.mjs
+++ b/lib/api.mjs
@@ -159,10 +159,10 @@ class API extends EventEmitter {
       method: 'POST',
       signal: controller.signal
     })
-    // Errors were ignored in original mega package
+      // Errors were ignored in original mega package
       .catch(() => {})
       .then(() => {
-      // Body is ignored here
+        // Body is ignored here
         this.sn = undefined
         this.pull(sn)
       })

--- a/lib/api.mjs
+++ b/lib/api.mjs
@@ -87,7 +87,7 @@ class API extends EventEmitter {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify([json])
-    }).then(response => response.json()).then(resp => {
+    }).then(handleApiResponse).then(resp => {
       if (this.closed && !isLogout) return
       if (!resp) return cb(Error('Empty response'))
 
@@ -124,7 +124,7 @@ class API extends EventEmitter {
     this.fetch(`${this.gateway}sc?${new URLSearchParams({ sn, sid: this.sid })}`, {
       method: 'POST',
       signal: controller.signal
-    }).then(response => response.json()).then(resp => {
+    }).then(handleApiResponse).then(resp => {
       this.sn = undefined
       if (this.closed) return
 
@@ -136,7 +136,7 @@ class API extends EventEmitter {
             }, Math.pow(2, retryno + 1) * 1e3)
           }
         }
-        throw Error(ERRORS[-resp])
+        this.emit('error', Error(ERRORS[-resp]))
       }
 
       if (resp.w) {
@@ -147,7 +147,9 @@ class API extends EventEmitter {
         }
         this.pull(resp.sn)
       }
-    }).catch(ignoreAbortError)
+    }).catch(ignoreAbortError).catch(error => {
+      this.emit('error', error)
+    })
   }
 
   wait (url, sn) {
@@ -156,12 +158,14 @@ class API extends EventEmitter {
     this.fetch(url, {
       method: 'POST',
       signal: controller.signal
-    }).then(() => {
+    })
+    // Errors were ignored in original mega package
+      .catch(() => {})
+      .then(() => {
       // Body is ignored here
-      // Errors were ignored in original mega package
-      this.sn = undefined
-      this.pull(sn)
-    }).catch(ignoreAbortError)
+        this.sn = undefined
+        this.pull(sn)
+      })
   }
 
   close () {
@@ -175,6 +179,19 @@ class API extends EventEmitter {
     }
     return API.globalApi
   }
+}
+
+function handleApiResponse (response) {
+  // Issue 130: handle 'Server Too Busy' as -3
+  if (response.statusText === 'Server Too Busy') {
+    return -3
+  }
+
+  if (!response.ok) {
+    throw Error(`Server returned error: ${response.statusText}`)
+  }
+
+  return response.json()
 }
 
 function ignoreAbortError (error) {


### PR DESCRIPTION
1. Check response status before calling .json() and handle them properly.
2. Emit or ignore errors instead of throwing.

Fixes https://github.com/qgustavor/mega/issues/130.