### PR TITLE
Fix Zalgo in Storage class

### DIFF
--- a/lib/storage.mjs
+++ b/lib/storage.mjs
@@ -14,17 +14,6 @@ class Storage extends EventEmitter {
       options = {}
     }
 
-    if (!options.email) {
-      throw Error("starting a session without credentials isn't supported")
-    }
-
-    if (!originalCb) {
-      originalCb = (err) => {
-        // Would be nicer to emit error event?
-        if (err) throw err
-      }
-    }
-
     // Because this is a constructor it can't return a promise
     // so the promise is make available via .ready
     const [cb, promise] = createPromise(originalCb)
@@ -38,18 +27,26 @@ class Storage extends EventEmitter {
     this.api = new API(options.keepalive, options)
     this.files = {}
     this.options = options
+    this.status = 'closed'
 
     if (options.autologin) {
       this.login(cb)
     } else {
-      cb(null, this)
+      process.nextTick(() => {
+        cb(null, this)
+      })
     }
-
-    this.status = 'closed'
   }
 
   login (originalCb) {
     const [cb, promise] = createPromise(originalCb)
+
+    if (typeof this.options.email !== 'string') {
+      process.nextTick(() => {
+        cb(Error("starting a session without credentials isn't supported"))
+      })
+      return promise
+    }
 
     const ready = () => {
       this.status = 'ready'

--- a/lib/util.mjs
+++ b/lib/util.mjs
@@ -75,8 +75,11 @@ function createPromise (originalCb) {
   let cb
   const promise = new Promise((resolve, reject) => {
     cb = (err, arg) => {
-      if (err) return reject(err)
-      resolve(arg)
+      if (err) {
+        reject(err)
+      } else {
+        resolve(arg)
+      }
     }
   })
 

--- a/test/helpers/test-runner.mjs
+++ b/test/helpers/test-runner.mjs
@@ -19,6 +19,10 @@ if (testedPlatform !== 'node' && testedPlatform !== 'deno') {
   testedPlatform = 'node'
 }
 
+const extraArguments = process.argv.includes('--')
+  ? process.argv.slice(process.argv.indexOf('--') + 1)
+  : []
+
 // Set up temporary directories
 const tempDir = await tmp.dir({
   prefix: 'megajs-tests',
@@ -121,7 +125,12 @@ let wasFailed = false
 // Run tests
 if (testedPlatform === 'node') {
   await new Promise(resolve => {
-    const subprocess = cp.spawn('npx', ['ava', '--', path.join(buildDir, '*.js')], {
+    const subprocess = cp.spawn('npx', [
+      'ava',
+      '--',
+      path.join(buildDir, '*.js'),
+      ...extraArguments
+    ], {
       stdio: 'inherit',
       shell: os.platform() === 'win32',
       env: {
@@ -145,7 +154,12 @@ if (testedPlatform === 'node') {
   })
 } else {
   await new Promise(resolve => {
-    const subprocess = cp.spawn('deno', ['test', '--allow-env=MEGA_MOCK_URL', '--allow-net=' + gateway.slice(7)], {
+    const subprocess = cp.spawn('deno', [
+      'test',
+      '--allow-env=MEGA_MOCK_URL',
+      '--allow-net=' + gateway.slice(7),
+      ...extraArguments
+    ], {
       cwd: buildDir,
       stdio: 'inherit',
       shell: os.platform() === 'win32',

--- a/test/storage.test.mjs
+++ b/test/storage.test.mjs
@@ -10,6 +10,85 @@ const gatewayUrl = typeof Deno !== 'undefined'
   : process.env.MEGA_MOCK_URL
 if (!gatewayUrl) throw Error('Missing MEGA_MOCK_URL environment variable')
 
+test.serial('Should require an email when logging to MEGA', t => {
+  return new Promise((resolve, reject) => {
+    // eslint-disable-next-line no-new
+    new Storage({
+      gateway: gatewayUrl
+    }, error => {
+      if (error) {
+        t.is(error.message, "starting a session without credentials isn't supported")
+        return resolve()
+      }
+      reject(Error('Unexpected success'))
+    })
+  })
+}, {
+  sanitizeResources: false,
+  sanitizeOps: false
+})
+
+test.serial('Should require an email when logging to MEGA using promises', t => {
+  return new Storage({
+    gateway: gatewayUrl
+  }).ready.then(() => {
+    throw Error('Unexpected success')
+  }, error => {
+    t.is(error.message, "starting a session without credentials isn't supported")
+  })
+}, {
+  sanitizeResources: false,
+  sanitizeOps: false
+})
+
+test.serial('Should require an email when logging to MEGA using .login()', t => {
+  return new Promise((resolve, reject) => {
+    const storage = new Storage({
+      autologin: false,
+      gateway: gatewayUrl
+    })
+
+    return storage.login(error => {
+      if (error) {
+        t.is(error.message, "starting a session without credentials isn't supported")
+        return resolve()
+      }
+      reject(Error('Unexpected success'))
+    })
+  })
+})
+
+test.serial('Should require an email when logging to MEGA using .login() and promises', t => {
+  const storage = new Storage({
+    autologin: false,
+    gateway: gatewayUrl
+  })
+
+  return storage.login().then(() => {
+    throw Error('Unexpected success')
+  }, error => {
+    t.is(error.message, "starting a session without credentials isn't supported")
+  })
+}, {
+  sanitizeResources: false,
+  sanitizeOps: false
+})
+
+test.serial('Should require valid credentials when logging to MEGA', t => {
+  const storage = new Storage({
+    email: 'invalid@credentials',
+    password: 'invalid',
+    autologin: false,
+    gateway: gatewayUrl
+  })
+
+  return storage.login().then(() => {
+    throw Error('Unexpected success')
+  }, error => {
+    t.is(error.message, 'ENOENT (-9): Object (typically, node or user) not found. Wrong password?')
+  })
+})
+
 const storage = new Storage({
   email: 'mock@test',
   password: 'mock',


### PR DESCRIPTION
1. Added tests for checking for Zalgo
2. Moved email check to `.login()` so it would not run in the constructor
3. Added process.nextTick to avoid Zalgo
4. Added option to use additional arguments when testing (to enable debugging)
5. Improved createPromise implementation (it should compress better)