### PR TITLE
Release - v1.2.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,6 +8,8 @@ assignees: ''
 ---
 
 <!--
+IMPORTANT! Read this before continuing: https://github.com/qgustavor/mega/discussions/138
+
 Please only post issues here. Since 1.0 was released other kind of messages such as questions and feature requests are now available in the discussions tab since it's better suited for that.
 -->
 
@@ -21,10 +23,6 @@ Run this code in Node X.XX (or Deno/Firefox/Chromium/Cloudflare Workers/etc):
 ```js
 import { Storage } from 'megajs'
 // edit this with your code
-
-// if your code includes passwords and you think the issue
-// is in the password hashing code replace those with
-// "*n-length password*" (where "n" is the length of the password)
 ```
 
 **Expected behavior**

--- a/lib/api.mjs
+++ b/lib/api.mjs
@@ -24,7 +24,16 @@ const ERRORS = {
   15: 'ESID (-15): Invalid or expired user session, please relogin',
   16: 'EBLOCKED (-16): User blocked',
   17: 'EOVERQUOTA (-17): Request over quota',
-  18: 'ETEMPUNAVAIL (-18): Resource temporarily not available, please try again later'
+  18: 'ETEMPUNAVAIL (-18): Resource temporarily not available, please try again later',
+  19: 'ETOOMANYCONNECTIONS (-19)',
+  24: 'EGOINGOVERQUOTA (-24)',
+  25: 'EROLLEDBACK (-25)',
+  26: 'EMFAREQUIRED (-26): Multi-Factor Authentication Required',
+  27: 'EMASTERONLY (-27)',
+  28: 'EBUSINESSPASTDUE (-28)',
+  29: 'EPAYWALL (-29): ODQ paywall state',
+  400: 'ETOOERR (-400)',
+  401: 'ESHAREROVERQUOTA (-401)'
 }
 
 const DEFAULT_GATEWAY = 'https://g.api.mega.co.nz/'

--- a/lib/crypto/index.mjs
+++ b/lib/crypto/index.mjs
@@ -106,7 +106,7 @@ function megaVerify (key) {
   let stream = new Transform({
     transform (chunk, encoding, callback) {
       mac.update(chunk)
-      callback(null, chunk)
+      callback(null)
     },
     flush (callback) {
       stream.mac = mac.condense()

--- a/lib/storage.mjs
+++ b/lib/storage.mjs
@@ -77,9 +77,6 @@ class Storage extends EventEmitter {
     const handleV1Account = (cb) => {
       const pw = prepareKey(Buffer.from(this.options.password))
 
-      // after generating the AES key the password isn't needed anymore
-      delete this.options.password
-
       const aes = new AES(pw)
       const uh = e64(aes.stringhash(Buffer.from(this.email)))
       const request = { a: 'us', user: this.email, uh }
@@ -90,9 +87,6 @@ class Storage extends EventEmitter {
       prepareKeyV2(Buffer.from(this.options.password), info, (err, result) => {
         if (err) return cb(err)
 
-        // after generating the AES key the password isn't needed anymore
-        delete this.options.password
-
         const aes = new AES(result.slice(0, 16))
         const uh = e64(result.slice(16))
         const request = { a: 'us', user: this.email, uh }
@@ -101,6 +95,14 @@ class Storage extends EventEmitter {
     }
 
     const finishLogin = (request, aes, cb) => {
+      // after generating the AES key the password isn't needed anymore
+      // delete it to reduce the possibility of someone leaking it
+      delete this.options.password
+
+      if (this.options.secondFactorCode) {
+        request.mfa = this.options.secondFactorCode.toString()
+      }
+
       this.api.request(request, (err, response) => {
         if (err) return cb(err)
         this.key = formatKey(response.k)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3478,9 +3478,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -8523,9 +8523,9 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"


### PR DESCRIPTION
# Release v1.2.0

<a name="changeSummary-start"></a>

- #146
- #145
- #144
- #140

<a name="changeSummary-end"></a>
        
## Changelog

<a name="changelog-start"></a>
### Minor Changes

#### [Fix verify (@qgustavor)](https://github.com/qgustavor/mega/pull/146)

~~It was requiring .resume(), which was not intended nor documented.~~ `.verify()` does not return the input anymore. The idea was fixing the need to a `.resume()` but it didn't work. I will not reverse that, at least I hope it reduces memory usage.
#### [Update PR template (@qgustavor)](https://github.com/qgustavor/mega/pull/145)


#### [Add support to 2FA (@qgustavor)](https://github.com/qgustavor/mega/pull/144)

My account uses 2FA, so it need it implemented.  Also updated error codes.
#### [Bump json5 from 1.0.1 to 1.0.2 (@dependabot[bot])](https://github.com/qgustavor/mega/pull/140)

Bumps [json5](https://github.com/json5/json5) from 1.0.1 to 1.0.2.  Release notes.  Sourced from json5's releases.  v1.0.2.
               
<a name="changelog-end"></a>
           
           
           
        