### PR TITLE
Add support to 2FA

### DIFF
--- a/lib/api.mjs
+++ b/lib/api.mjs
@@ -24,7 +24,16 @@ const ERRORS = {
   15: 'ESID (-15): Invalid or expired user session, please relogin',
   16: 'EBLOCKED (-16): User blocked',
   17: 'EOVERQUOTA (-17): Request over quota',
-  18: 'ETEMPUNAVAIL (-18): Resource temporarily not available, please try again later'
+  18: 'ETEMPUNAVAIL (-18): Resource temporarily not available, please try again later',
+  19: 'ETOOMANYCONNECTIONS (-19)',
+  24: 'EGOINGOVERQUOTA (-24)',
+  25: 'EROLLEDBACK (-25)',
+  26: 'EMFAREQUIRED (-26): Multi-Factor Authentication Required',
+  27: 'EMASTERONLY (-27)',
+  28: 'EBUSINESSPASTDUE (-28)',
+  29: 'EPAYWALL (-29): ODQ paywall state',
+  400: 'ETOOERR (-400)',
+  401: 'ESHAREROVERQUOTA (-401)'
 }
 
 const DEFAULT_GATEWAY = 'https://g.api.mega.co.nz/'

--- a/lib/storage.mjs
+++ b/lib/storage.mjs
@@ -80,9 +80,6 @@ class Storage extends EventEmitter {
     const handleV1Account = (cb) => {
       const pw = prepareKey(Buffer.from(this.options.password))
 
-      // after generating the AES key the password isn't needed anymore
-      delete this.options.password
-
       const aes = new AES(pw)
       const uh = e64(aes.stringhash(Buffer.from(this.email)))
       const request = { a: 'us', user: this.email, uh }
@@ -93,9 +90,6 @@ class Storage extends EventEmitter {
       prepareKeyV2(Buffer.from(this.options.password), info, (err, result) => {
         if (err) return cb(err)
 
-        // after generating the AES key the password isn't needed anymore
-        delete this.options.password
-
         const aes = new AES(result.slice(0, 16))
         const uh = e64(result.slice(16))
         const request = { a: 'us', user: this.email, uh }
@@ -104,6 +98,14 @@ class Storage extends EventEmitter {
     }
 
     const finishLogin = (request, aes, cb) => {
+      // after generating the AES key the password isn't needed anymore
+      // delete it to reduce the possibility of someone leaking it
+      delete this.options.password
+
+      if (this.options.secondFactorCode) {
+        request.mfa = this.options.secondFactorCode.toString()
+      }
+
       this.api.request(request, (err, response) => {
         if (err) return cb(err)
         this.key = formatKey(response.k)


### PR DESCRIPTION
My account uses 2FA, so it need it implemented. Also updated error codes.

Deduplicated some code and added a note about deleting the password since some people removed this line in forks. Maybe someone might post the result of a `console.log(storage)` with the password, which is something someone could easily notice as being a secret. The `sid` and `key` are also secrets, but those cannot be deleted since the library needs them to work with the API, the password is only used during login.