### PR TITLE
Fix verify

### DIFF
--- a/lib/crypto/index.mjs
+++ b/lib/crypto/index.mjs
@@ -106,7 +106,7 @@ function megaVerify (key) {
   let stream = new Transform({
     transform (chunk, encoding, callback) {
       mac.update(chunk)
-      callback(null, chunk)
+      callback(null)
     },
     flush (callback) {
       stream.mac = mac.condense()


### PR DESCRIPTION
It was requiring .resume(), which was not intended nor documented.