### PR TITLE
Fix provenance in pre-releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
     "Gustavo Rodrigues (https://qgustavor.tk)"
   ],
   "license": "MIT",
+  "publishConfig": {
+    "provenance": true
+  },
   "dependencies": {
     "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.7",


### PR DESCRIPTION
As pr-release does not allow setting --provenance when publishing pre-releases yet, the provenance config is set on package.json