### PR TITLE
Handle upload progress better and don't minify browser-es

### DIFF
--- a/build.js
+++ b/build.js
@@ -20,7 +20,7 @@ const formats = [{
   // to be loaded with ES Module compatible loader
   name: 'browser-es',
   bundleExternals: true,
-  minifyResult: true,
+  minifyResult: false,
   entryPoints: ['lib/mega.mjs'],
   bundleFormat: 'esm',
   platform: 'browser',

--- a/lib/mutable-file.mjs
+++ b/lib/mutable-file.mjs
@@ -358,6 +358,7 @@ class MutableFile extends File {
     const sendChunk = () => {
       const chunkPosition = position
       const chunkBuffer = uploadBuffer
+      let bytesUploaded = 0
       let tries = 0
 
       const trySendChunk = () => {
@@ -374,6 +375,9 @@ class MutableFile extends File {
           }
           return response.arrayBuffer()
         }).then(hash => {
+          bytesUploaded += chunkBuffer.length
+          stream.emit('progress', { bytesLoaded: sizeCheck, bytesUploaded, bytesTotal: size })
+
           const hashBuffer = Buffer.from(hash)
           if (hashBuffer.length > 0) {
             source.end()
@@ -412,7 +416,6 @@ class MutableFile extends File {
           break
         }
         sizeCheck += data.length
-        stream.emit('progress', { bytesLoaded: sizeCheck, bytesTotal: size })
 
         data.copy(uploadBuffer, chunkPos)
         chunkPos += data.length


### PR DESCRIPTION
Upload progress can be monitored by checking progress events. The browser-es build is no longer minified because I guess no one using it wants it to be minified, instead they would opt to use a minifier from a bundler which also would do tree shaking. Of they are using Deno, which, in this case, it's better not to minify to make debugging easier.