### PR TITLE
Release - v1.1.7

### DIFF
--- a/lib/mutable-file.mjs
+++ b/lib/mutable-file.mjs
@@ -327,6 +327,7 @@ class MutableFile extends File {
     let remainingBuffer
     let uploadBuffer, uploadURL
     let chunkSize, chunkPos
+    let bytesUploaded = 0
 
     const handleChunk = () => {
       chunkSize = Math.min(currentChunkSize, size - position)
@@ -358,7 +359,6 @@ class MutableFile extends File {
     const sendChunk = () => {
       const chunkPosition = position
       const chunkBuffer = uploadBuffer
-      let bytesUploaded = 0
       let tries = 0
 
       const trySendChunk = () => {


### PR DESCRIPTION

# Release v1.1.7

<a name="changeSummary-start"></a>

- #173

<a name="changeSummary-end"></a>
        
## Changelog

<a name="changelog-start"></a>
### Patch Changes

#### [Fix upload progress (@qgustavor)](https://github.com/qgustavor/mega/pull/173)

bytesUploaded was defined inside sendChunk, not inside _uploadWithSize.
   
<a name="changelog-end"></a>
           
        