### PR TITLE
Fix package.json's exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,15 +8,21 @@
     ".": {
       "import": {
         "types": "./types/es.d.ts",
+        "deno": "./dist/main.browser-es.mjs",
         "node": "./dist/main.node-es.mjs",
         "default": "./dist/main.browser-es.mjs"
       },
       "require": {
         "types": "./types/cjs.d.ts",
+        "deno": "./dist/main.browser-umd.js",
         "node": "./dist/main.node-cjs.js",
-        "default": "./dist/main.browser-cjs.js"
+        "default": "./dist/main.browser-umd.js"
       }
-    }
+    },
+    "./dist/main.node-cjs.js": "./dist/main.node-cjs.js",
+    "./dist/main.browser-es.mjs": "./dist/main.browser-es.mjs",
+    "./dist/main.node-es.mjs": "./dist/main.node-es.mjs",
+    "./dist/main.browser-umd.js": "./dist/main.browser-umd.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
It should be "browser-umd.js" instead of "browser-cjs.js" and it should include a "deno" resolver above the "node" resolver as Deno assumes it's Node.js when resolving and prioritizes the "node" resolver" over "default."

**Deno's documentation which is at blame! It's not documented, I had to look [at the Rust code](https://github.com/denoland/deno/blob/850331164138233ea86c9a5032d99ad29c79efe1/ext/node/resolution.rs#L30)!**

About the umd fix: sorry. 😞 