### PR TITLE
Use .bind to avoid fetch error

### DIFF
--- a/lib/api.mjs
+++ b/lib/api.mjs
@@ -75,7 +75,7 @@ class API extends EventEmitter {
 
     if (!API.fetchModule) {
       if (typeof globalThis.fetch === 'function') {
-        API.fetchModule = globalThis.fetch
+        API.fetchModule = globalThis.fetch.bind(globalThis)
       } else {
         const nodeFetch = await import('node-fetch')
         API.fetchModule = nodeFetch.fetch


### PR DESCRIPTION
Avoids "'fetch' called on an object that does not implement interface Window."