### PR TITLE
Add checks for Firefox and Deno

### DIFF
--- a/lib/api.mjs
+++ b/lib/api.mjs
@@ -48,7 +48,8 @@ class API extends EventEmitter {
 
     // Set up a default user agent and keep-alive agent
     const packageVersion = process.env.PACKAGE_VERSION
-    this.userAgent = opt.userAgent === null
+    const shouldAvoidUA = API.getShouldAvoidUA()
+    this.userAgent = opt.userAgent === null || shouldAvoidUA
       ? null
       : `${opt.userAgent || ''} megajs/${packageVersion}`.trim()
 
@@ -194,6 +195,31 @@ class API extends EventEmitter {
       API.globalApi = new API()
     }
     return API.globalApi
+  }
+
+  static handleForceHttps (userOpt) {
+    if (userOpt != null) return userOpt
+    if (globalThis.Deno) return false
+    return process.env.IS_BROWSER_BUILD
+  }
+
+  static getShouldAvoidUA () {
+    // Checks defined using
+    // - https://codepen.io/qgustavor/pen/JjqqBPp
+    // - https://www.browserstack.com/screenshots/149d6d45a4a10de06e05f743190a4c12a9faa6ef
+
+    // It's not possible to detect when a browser fails CORS requests by defining an user-agent
+    // using feature detection, so the alternatives were using user-agent detection
+    // (which is not ideal because might not catch Firefox forks) or hacks.
+
+    // This library uses hacks:
+    let headersErr
+    try {
+      globalThis.Headers()
+    } catch (err) {
+      headersErr = err.message
+    }
+    return !((globalThis.fetch + '').length === 38 && headersErr.includes('Headers'))
   }
 }
 

--- a/lib/file.mjs
+++ b/lib/file.mjs
@@ -177,7 +177,7 @@ class File extends EventEmitter {
     const initialChunkSize = options.initialChunkSize || 128 * 1024
     const chunkSizeIncrement = options.chunkSizeIncrement || 128 * 1024
     const maxChunkSize = options.maxChunkSize || 1024 * 1024
-    const ssl = (options.forceHttps ?? process.env.IS_BROWSER_BUILD) ? 2 : 0
+    const ssl = API.handleForceHttps(options.forceHttps) ? 2 : 0
 
     const req = {
       a: 'g',

--- a/lib/mutable-file.mjs
+++ b/lib/mutable-file.mjs
@@ -305,7 +305,7 @@ class MutableFile extends File {
   }
 
   _uploadWithSize (stream, size, source, type, opt, cb) {
-    const ssl = (opt.forceHttps ?? process.env.IS_BROWSER_BUILD) ? 2 : 0
+    const ssl = this.api.handleForceHttps(opt.forceHttps) ? 2 : 0
     const getUrlRequest = type === 0
       ? { a: 'u', ssl, s: size, ms: 0, r: 0, e: 0, v: 2 }
       : { a: 'ufa', ssl, s: size }


### PR DESCRIPTION
Add checks for Firefox and Deno so having to set `userAgent: null` or `forceHttps: false` is no longer required. If something breaks those checks can be disabled by overriding `API.handleForceHttps`and `API.getShouldAvoidUA`.