### PR TITLE
Release - v1.3.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ import { Storage } from 'megajs'
 // edit this with your code
 ```
 
-<!-- THIS IS IMPORTANT! It's really hard to debug an issue, sometimes impossible, without a reproductible example! -->
+<!-- THIS IS IMPORTANT! It's really hard to debug an issue, sometimes impossible, without a reproducible example! -->
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,14 +7,10 @@ assignees: ''
 
 ---
 
-<!--
-IMPORTANT! Read this before continuing: https://github.com/qgustavor/mega/discussions/138
-
-Please only post issues here. Since 1.0 was released other kind of messages such as questions and feature requests are now available in the discussions tab since it's better suited for that.
--->
-
 **Describe the bug**
 A clear and concise description of what the bug is.
+
+<!-- If you have error stacks, include then here using ``` at the beginning and at the end -->
 
 **To Reproduce**
 
@@ -24,6 +20,8 @@ Run this code in Node X.XX (or Deno/Firefox/Chromium/Cloudflare Workers/etc):
 import { Storage } from 'megajs'
 // edit this with your code
 ```
+
+<!-- THIS IS IMPORTANT! It's really hard to debug an issue, sometimes impossible, without a reproductible example! -->
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.

--- a/lib/api.mjs
+++ b/lib/api.mjs
@@ -137,8 +137,9 @@ class API extends EventEmitter {
 
   pull (sn, retryno = 0) {
     const controller = new AbortController()
+    const ssl = API.handleForceHttps() ? 1 : 0
     this.sn = controller
-    this.fetch(`${this.gateway}sc?${new URLSearchParams({ sn, sid: this.sid })}`, {
+    this.fetch(`${this.gateway}sc?${new URLSearchParams({ sn, ssl, sid: this.sid })}`, {
       method: 'POST',
       signal: controller.signal
     }).then(handleApiResponse).then(resp => {

--- a/lib/api.mjs
+++ b/lib/api.mjs
@@ -200,8 +200,7 @@ class API extends EventEmitter {
 
   static handleForceHttps (userOpt) {
     if (userOpt != null) return userOpt
-    if (globalThis.Deno) return false
-    return process.env.IS_BROWSER_BUILD
+    return !!(globalThis.isSecureContext)
   }
 
   static getShouldAvoidUA () {

--- a/lib/file.mjs
+++ b/lib/file.mjs
@@ -463,7 +463,7 @@ class File extends EventEmitter {
 
     return this.children.reduce((results, entry) => {
       if (entry.children) {
-        if (deep) return results.concat(entry.find(query, deep))
+        if (deep) return results.concat(entry.filter(query, deep))
         return results
       }
       return query(entry) ? results.concat(entry) : results

--- a/lib/file.mjs
+++ b/lib/file.mjs
@@ -470,7 +470,7 @@ class File extends EventEmitter {
     }, [])
   }
 
-  navigate (query, deep) {
+  navigate (query) {
     if (!this.children) throw Error('You can only call .navigate on directories')
 
     if (typeof query === 'string') {

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ How to contribute using pull requests:
    - Fix issues
    - Add features
    - Refactor things
+- Update TypeScript types if needed
 - `npm run lint-fix` to fix common issues
 - Build the bundled versions using `npm run build`
 - Run at least Node tests using `npm test node` to test Node

--- a/test/helpers/test-runner.mjs
+++ b/test/helpers/test-runner.mjs
@@ -158,7 +158,7 @@ if (testedPlatform === 'node') {
     const subprocess = cp.spawn('deno', [
       'test',
       '--allow-env=MEGA_MOCK_URL',
-      '--allow-net=' + gateway.slice(7),
+      '--allow-net=' + gateway.slice(7, -1),
       ...extraArguments
     ], {
       cwd: buildDir,

--- a/types/cjs.d.ts
+++ b/types/cjs.d.ts
@@ -31,6 +31,8 @@ declare namespace megajs {
     inbox: MutableFile
     mounts: MutableFile[]
     files: { [id in string]: MutableFile }
+    filter (query: string | string[] | ((file: MutableFile) => boolean), deep?: boolean): MutableFile[]
+    find (query: string | string[] | ((file: MutableFile) => boolean), deep?: boolean): MutableFile | null
     RSAPrivateKey: Array<number | number[]>
     ready: Promise<this>
     constructor (options: StorageOpts, cb?: errorCb)
@@ -123,6 +125,7 @@ declare namespace megajs {
     moveTo (target: File | string, cb?: (error: err, data?: any) => void): Promise<void>
     upload (opts: uploadOpts | string, source?: BufferString, cb?: uploadCb): Writable
     mkdir (opts: mkdirOpts | string, cb?: (error: err, file: MutableFile) => void): Promise<MutableFile>
+    navigate (query: string | string[]): MutableFile | undefined
     uploadAttribute (type: uploadAttrType, data: Buffer, cb?: (error: err, file?: this) => void): Promise<this>
     importFile (sharedFile: string | File, cb?: (error: err, file?: this) => void): Promise<MutableFile>
     on (event: 'move', listener: (oldDir: File) => void): this

--- a/types/cjs.d.ts
+++ b/types/cjs.d.ts
@@ -157,6 +157,7 @@ declare namespace megajs {
     interface StorageOpts extends APIOpts {
       email: string
       password: BufferString
+      secondFactorCode?: string
       autoload?: boolean
       autologin?: boolean
       keepalive?: boolean

--- a/types/cjs.d.ts
+++ b/types/cjs.d.ts
@@ -68,6 +68,8 @@ declare namespace megajs {
     sn?: AbortController
     static globalApi?: API
     static getGlobalApi (): API
+    static handleForceHttps (userOpt?: boolean): boolean
+    static getShouldAvoidUA (): boolean
     constructor (keepalive: boolean, opts?: APIOpts)
     close (): void
     pull (sn: AbortController, retryno?: number): void

--- a/types/es.d.ts
+++ b/types/es.d.ts
@@ -149,6 +149,7 @@ type noop = () => void
 interface StorageOpts extends APIOpts {
   email: string
   password: BufferString
+  secondFactorCode?: string
   autoload?: boolean
   autologin?: boolean
   keepalive?: boolean

--- a/types/es.d.ts
+++ b/types/es.d.ts
@@ -24,6 +24,8 @@ export declare class Storage extends EventEmitter {
   inbox: MutableFile
   mounts: MutableFile[]
   files: { [id in string]: MutableFile }
+  filter (query: string | string[] | ((file: MutableFile) => boolean), deep?: boolean): MutableFile[]
+  find (query: string | string[] | ((file: MutableFile) => boolean), deep?: boolean): MutableFile | null
   RSAPrivateKey: Array<number | number[]>
   ready: Promise<this>
   constructor (options: StorageOpts, cb?: errorCb)
@@ -116,6 +118,7 @@ declare class MutableFile extends File {
   moveTo (target: File | string, cb?: (error: err, data?: any) => void): Promise<void>
   upload (opts: uploadOpts | string, source?: BufferString, cb?: uploadCb): Writable
   mkdir (opts: mkdirOpts | string, cb?: (error: err, file: MutableFile) => void): Promise<MutableFile>
+  navigate (query: string | string[]): MutableFile | undefined
   uploadAttribute (type: uploadAttrType, data: Buffer, cb?: (error: err, file?: this) => void): Promise<this>
   importFile (sharedFile: string | File, cb?: (error: err, file?: this) => void): Promise<MutableFile>
   on (event: 'move', listener: (oldDir: File) => void): this

--- a/types/es.d.ts
+++ b/types/es.d.ts
@@ -61,6 +61,8 @@ export declare class API extends EventEmitter {
   sn?: AbortController
   static globalApi?: API
   static getGlobalApi (): API
+  static handleForceHttps (userOpt?: boolean): boolean
+  static getShouldAvoidUA (): boolean
   constructor (keepalive: boolean, opts?: APIOpts)
   close (): void
   pull (sn: AbortController, retryno?: number): void


### PR DESCRIPTION
# Release v1.3.1

<a name="changeSummary-start"></a>

- #211
- #209
- #210
- #208
- #207
- #206
- #204
- #202
- #200

<a name="changeSummary-end"></a>
        
## Changelog

<a name="changelog-start"></a>
### Patch Changes

#### [Simplify handleForceHttps (@qgustavor)](https://github.com/qgustavor/mega/pull/211)

Use `globalThis.isSecureContext`.  Advantages and disadvantages shown in detail [here](https://github.com/qgustavor/mega/issues/205#issuecomment-2333901645).
#### [Handle `ssl` in API's pull request so Storage works in browsers (@qgustavor)](https://github.com/qgustavor/mega/pull/209)

Should fix issue #205 where the Storage class does not work on HTTPS websites.
#### [Fix .filter implementation (@qgustavor)](https://github.com/qgustavor/mega/pull/210)

It was calling .find instead of calling .filter to recurse directories.
#### [Add a note about updating TypeScript types (@qgustavor)](https://github.com/qgustavor/mega/pull/208)

I always forget about that, so is better to put it in the readme.
#### [Fix Deno tests (@qgustavor)](https://github.com/qgustavor/mega/pull/207)

--allow-net should not include a trailing slash.
#### [TS fix: find,filter,navigate in `storage` (@xmok)](https://github.com/qgustavor/mega/pull/206)

I'm not sure if the return type of `navigate` is correct - could anyone verify?.
#### [TS fix: `secondFactorCode` type was missing in Storage constructor (TS) (@xmok)](https://github.com/qgustavor/mega/pull/204)


#### [Fix typo in the template (@qgustavor)](https://github.com/qgustavor/mega/pull/202)


#### [Improve bug report template (@qgustavor)](https://github.com/qgustavor/mega/pull/200)


               
<a name="changelog-end"></a>
           
           
           
           
           
           
           
           
           
        