### PR TITLE
Handle `ssl` in API's pull request so Storage works in browsers

### DIFF
--- a/lib/api.mjs
+++ b/lib/api.mjs
@@ -137,8 +137,9 @@ class API extends EventEmitter {
 
   pull (sn, retryno = 0) {
     const controller = new AbortController()
+    const ssl = API.handleForceHttps() ? 1 : 0
     this.sn = controller
-    this.fetch(`${this.gateway}sc?${new URLSearchParams({ sn, sid: this.sid })}`, {
+    this.fetch(`${this.gateway}sc?${new URLSearchParams({ sn, ssl, sid: this.sid })}`, {
       method: 'POST',
       signal: controller.signal
     }).then(handleApiResponse).then(resp => {

--- a/types/cjs.d.ts
+++ b/types/cjs.d.ts
@@ -68,6 +68,8 @@ declare namespace megajs {
     sn?: AbortController
     static globalApi?: API
     static getGlobalApi (): API
+    static handleForceHttps (userOpt?: boolean): boolean
+    static getShouldAvoidUA (): boolean
     constructor (keepalive: boolean, opts?: APIOpts)
     close (): void
     pull (sn: AbortController, retryno?: number): void

--- a/types/es.d.ts
+++ b/types/es.d.ts
@@ -61,6 +61,8 @@ export declare class API extends EventEmitter {
   sn?: AbortController
   static globalApi?: API
   static getGlobalApi (): API
+  static handleForceHttps (userOpt?: boolean): boolean
+  static getShouldAvoidUA (): boolean
   constructor (keepalive: boolean, opts?: APIOpts)
   close (): void
   pull (sn: AbortController, retryno?: number): void


### PR DESCRIPTION
Should fix issue #205 where the Storage class does not work on HTTPS websites.

Draft as I will have to test it on some browsers and [because of this vote](https://github.com/qgustavor/mega/issues/205#issuecomment-2333901645).