### PR TITLE
Fix .filter implementation

### DIFF
--- a/lib/file.mjs
+++ b/lib/file.mjs
@@ -463,7 +463,7 @@ class File extends EventEmitter {
 
     return this.children.reduce((results, entry) => {
       if (entry.children) {
-        if (deep) return results.concat(entry.find(query, deep))
+        if (deep) return results.concat(entry.filter(query, deep))
         return results
       }
       return query(entry) ? results.concat(entry) : results


### PR DESCRIPTION
It was calling .find instead of calling .filter to recurse directories