### PR TITLE
Simplify handleForceHttps

### DIFF
--- a/lib/api.mjs
+++ b/lib/api.mjs
@@ -200,8 +200,7 @@ class API extends EventEmitter {
 
   static handleForceHttps (userOpt) {
     if (userOpt != null) return userOpt
-    if (globalThis.Deno) return false
-    return process.env.IS_BROWSER_BUILD
+    return !!(globalThis.isSecureContext)
   }
 
   static getShouldAvoidUA () {


### PR DESCRIPTION
Use `globalThis.isSecureContext`. Advantages and disadvantages shown in detail [here](https://github.com/qgustavor/mega/issues/205#issuecomment-2333901645). In summary:

- It will allow `Storage` to be used in HTTP websites in Firefox.
- It will make downloads work over HTTP on HTTP pages on all browsers.
- It will simplify the code removing a `globalThis.Deno` check.