### PR TITLE
Add support for file versions

### DIFF
--- a/lib/mutable-file.mjs
+++ b/lib/mutable-file.mjs
@@ -7,7 +7,6 @@ import API from './api.mjs'
 
 const KEY_CACHE = {}
 
-// metadata can be mutated, not the content
 class MutableFile extends File {
   constructor (opt, storage) {
     super(opt)
@@ -107,7 +106,12 @@ class MutableFile extends File {
   }
 
   upload (opt, source, originalCb) {
-    if (!this.directory) throw Error('node is not a directory')
+    let folderNode = this
+    let overridenNode
+    if (!this.directory) {
+      overridenNode = this
+      folderNode = this.parent
+    }
     if (arguments.length === 2 && typeof source === 'function') {
       [originalCb, source] = [source, null]
     }
@@ -132,7 +136,8 @@ class MutableFile extends File {
       throw Error('Specify a file size or set allowUploadBuffering to true')
     }
 
-    if (!opt.target) opt.target = this
+    if (opt.target && overridenNode) throw Error('you can not override a node and define a target')
+    if (!opt.target) opt.target = folderNode
 
     let finalKey
     let key = formatKey(opt.key)
@@ -186,6 +191,10 @@ class MutableFile extends File {
         t: 0,
         a: e64(at),
         k: e64(storedKey)
+      }
+
+      if (overridenNode) {
+        fileObject.ov = overridenNode.nodeId
       }
 
       if (hashes.length !== 1) {

--- a/lib/mutable-file.mjs
+++ b/lib/mutable-file.mjs
@@ -106,12 +106,7 @@ class MutableFile extends File {
   }
 
   upload (opt, source, originalCb) {
-    let folderNode = this
-    let overridenNode
-    if (!this.directory) {
-      overridenNode = this
-      folderNode = this.parent
-    }
+    if (!this.directory) throw Error('node is not a directory')
     if (arguments.length === 2 && typeof source === 'function') {
       [originalCb, source] = [source, null]
     }
@@ -136,8 +131,11 @@ class MutableFile extends File {
       throw Error('Specify a file size or set allowUploadBuffering to true')
     }
 
-    if (opt.target && overridenNode) throw Error('you can not override a node and define a target')
-    if (!opt.target) opt.target = folderNode
+    if (opt.overridenNode && !opt.overridenNode.nodeId) {
+      throw Error('an overriden node must be a MutableFile')
+    }
+    if (opt.target && opt.overridenNode) throw Error('you can not override a node and define a target')
+    if (!opt.target) opt.target = this
 
     let finalKey
     let key = formatKey(opt.key)
@@ -193,8 +191,8 @@ class MutableFile extends File {
         k: e64(storedKey)
       }
 
-      if (overridenNode) {
-        fileObject.ov = overridenNode.nodeId
+      if (opt.overridenNode) {
+        fileObject.ov = opt.overridenNode.nodeId
       }
 
       if (hashes.length !== 1) {
@@ -479,6 +477,14 @@ class MutableFile extends File {
     })
 
     return promise
+  }
+
+  uploadVersion (source, originalCb) {
+    if (this.directory) throw Error('node is a directory')
+    return this.parent.upload({
+      name: this.name,
+      overridenNode: this
+    }, source, originalCb)
   }
 
   delete (permanent, cb) {


### PR DESCRIPTION
Calling .upload() on a file overrides it adding a new version.

Missing:

- Handle naming: it should use the original file name I guess.
- Handle how revisions work: at the moment the library is unaware of revisions and seems to always download the newest one.
- Testing: testing on the real server, then implementing the server logic in mega-mock, then writing tests, then testing on real server again