### PR TITLE
Handle RSA encrypted node keys

### DIFF
--- a/lib/file.mjs
+++ b/lib/file.mjs
@@ -53,7 +53,17 @@ class File extends EventEmitter {
 
     const parts = opt.k.split(':')
     this.key = formatKey(parts[parts.length - 1])
-    aes.decryptECB(this.key)
+
+    if (this.key.length <= 32) {
+      // Regular AES-ECB encrypted key
+      aes.decryptECB(this.key)
+    } else if (this.storage) {
+      // RSA encrypted key
+      this.key = this.storage.decryptRsaKey(this.key).slice(0, this.directory ? 16 : 32)
+    } else {
+      // Can't decrypt a RSA key without a storage
+      this.key = null
+    }
 
     if (opt.a) {
       this.decryptAttributes(opt.a)

--- a/lib/storage.mjs
+++ b/lib/storage.mjs
@@ -358,6 +358,10 @@ class Storage extends EventEmitter {
 
     return storage
   }
+
+  decryptRsaKey (ciphertext) {
+    return cryptoRsaDecrypt(ciphertext, this.RSAPrivateKey)
+  }
 }
 
 const NODE_TYPE_DRIVE = 2


### PR DESCRIPTION
It checks for keys larger than 32 bytes and decrypt those with the user's RSA key if possible. Should fix accounts with the MEGAdrop feature enabled.

Tests for this feature are missing.

Fixes #218