### PR TITLE
All directories should contain a .children property

### DIFF
--- a/lib/file.mjs
+++ b/lib/file.mjs
@@ -17,6 +17,7 @@ class File extends EventEmitter {
     this.key = opt.key ? formatKey(opt.key) : null
     this.type = opt.directory ? 1 : 0
     this.directory = !!opt.directory
+    if (this.directory) this.children = []
 
     // Accept an API object
     this.api = opt.api || API.getGlobalApi()
@@ -48,6 +49,7 @@ class File extends EventEmitter {
     this.directory = !!opt.t
     this.owner = opt.u
     this.name = null
+    if (this.directory) this.children = []
 
     if (!aes || !opt.k) return
 
@@ -136,7 +138,6 @@ class File extends EventEmitter {
           const parent = filesMap[file.p]
           if (parent) {
             const fileObj = filesMap[file.h]
-            if (!parent.children) parent.children = []
             parent.children.push(fileObj)
             fileObj.parent = parent
           }

--- a/lib/mutable-file.mjs
+++ b/lib/mutable-file.mjs
@@ -18,6 +18,7 @@ class MutableFile extends File {
     this.timestamp = opt.ts
     this.type = opt.t
     this.directory = !!this.type
+    if (this.directory) this.children = []
 
     if (opt.k) {
       const idKeyPairs = opt.k.split('/')

--- a/lib/storage.mjs
+++ b/lib/storage.mjs
@@ -207,7 +207,6 @@ class Storage extends EventEmitter {
               // todo: move to setParent() to avoid duplicate.
               oldparent.children.splice(oldparent.children.indexOf(file), 1)
               file.parent = this.files[f.p]
-              if (!file.parent.children) file.parent.children = []
               file.parent.children.push(file)
               file.emit('move', oldparent)
               this.emit('move', file, oldparent)
@@ -254,7 +253,6 @@ class Storage extends EventEmitter {
 
         // Issue 58: some accounts have orphan files
         if (parent) {
-          if (!parent.children) parent.children = []
           parent.children.push(file)
           file.parent = parent
         }

--- a/test/storage.test.mjs
+++ b/test/storage.test.mjs
@@ -566,6 +566,12 @@ test.serial('Should navigate to files using strings', t => {
   t.is(matchingFile.size, 16)
 })
 
+test.serial('All directories should have children', t => {
+  for (const node of Object.values(storage.files)) {
+    t.is(!!node.directory, !!node.children)
+  }
+})
+
 test.serial('Should logout from MEGA', t => {
   return new Promise((resolve, reject) => {
     storage.close((error) => {


### PR DESCRIPTION
Moved `.children = []` handling from the code that handles children to the code that creates the node. In the end, three lines removed, three lines added. And a test.

Fixes #223