### PR TITLE
Release - v1.3.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
 
     strategy:
       matrix:
-        deno-version: [v1.x]
+        deno-version: [v2.x]
 
     steps:
     - uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
       with:
         cache: 'npm'
     - name: Use Deno ${{ matrix.deno-version }}
-      uses: denoland/setup-deno@v1
+      uses: denoland/setup-deno@v2
       with:
         deno-version: ${{ matrix.deno-version }}
     - run: npm ci

--- a/browser/aes.mjs
+++ b/browser/aes.mjs
@@ -35,16 +35,18 @@ export function prepareKeyV2 (password, info, cb) {
   const iterations = 100000
   const digest = 'SHA-512'
 
-  window.crypto.subtle.importKey('raw', password, 'PBKDF2', false, ['deriveKey', 'deriveBits']).then(key => {
-    return window.crypto.subtle.deriveBits({
-      name: 'PBKDF2',
-      salt,
-      iterations,
-      hash: { name: digest }
-    }, key, 256)
-  }).then(result => {
-    cb(null, Buffer.from(result))
-  }).catch(cb)
+  Promise.resolve()
+    .then(() => globalThis.crypto.subtle.importKey('raw', password, 'PBKDF2', false, ['deriveKey', 'deriveBits']))
+    .then(key => {
+      return globalThis.crypto.subtle.deriveBits({
+        name: 'PBKDF2',
+        salt,
+        iterations,
+        hash: { name: digest }
+      }, key, 256)
+    }).then(result => {
+      cb(null, Buffer.from(result))
+    }).catch(cb)
 }
 
 class AES {

--- a/lib/crypto/index.mjs
+++ b/lib/crypto/index.mjs
@@ -1,7 +1,6 @@
 import { Transform } from 'stream'
 import pumpify from 'pumpify'
 import { chunkSizeSafe } from '../util.mjs'
-import secureRandom from 'secure-random'
 import { AES, CTR, MAC, prepareKey, prepareKeyV2 } from './aes.mjs'
 
 export { AES, CTR, MAC, prepareKey, prepareKeyV2 }
@@ -35,7 +34,7 @@ function megaEncrypt (key, options = {}) {
   key = formatKey(key)
 
   if (!key) {
-    key = secureRandom(24)
+    key = globalThis.crypto.getRandomValues(new Uint8Array(24))
   }
   if (!(key instanceof Buffer)) {
     key = Buffer.from(key)

--- a/lib/file.mjs
+++ b/lib/file.mjs
@@ -17,7 +17,7 @@ class File extends EventEmitter {
     this.key = opt.key ? formatKey(opt.key) : null
     this.type = opt.directory ? 1 : 0
     this.directory = !!opt.directory
-    if (this.directory) this.children = []
+    if (this.directory && !this.children) this.children = []
 
     // Accept an API object
     this.api = opt.api || API.getGlobalApi()
@@ -49,7 +49,7 @@ class File extends EventEmitter {
     this.directory = !!opt.t
     this.owner = opt.u
     this.name = null
-    if (this.directory) this.children = []
+    if (this.directory && this.children) this.children = []
 
     if (!aes || !opt.k) return
 

--- a/lib/mutable-file.mjs
+++ b/lib/mutable-file.mjs
@@ -1,5 +1,4 @@
 import File, { LABEL_NAMES } from './file.mjs'
-import secureRandom from 'secure-random'
 import { PassThrough } from 'stream'
 import { e64, getCipher, megaEncrypt, formatKey, AES, unmergeKeyMac } from './crypto/index.mjs'
 import { detectSize, streamToCb, createPromise } from './util.mjs'
@@ -18,7 +17,7 @@ class MutableFile extends File {
     this.timestamp = opt.ts
     this.type = opt.t
     this.directory = !!this.type
-    if (this.directory) this.children = []
+    if (this.directory && !this.children) this.children = []
 
     if (opt.k) {
       const idKeyPairs = opt.k.split('/')
@@ -64,7 +63,7 @@ class MutableFile extends File {
     }
 
     if (!opt.target) opt.target = this
-    if (!opt.key) opt.key = Buffer.from(secureRandom(16))
+    if (!opt.key) opt.key = Buffer.from(globalThis.crypto.getRandomValues(new Uint8Array(16)))
 
     if (opt.key.length !== 16) {
       throw Error('wrong key length, must be 128bit')
@@ -137,7 +136,7 @@ class MutableFile extends File {
 
     let finalKey
     let key = formatKey(opt.key)
-    if (!key) key = secureRandom(24)
+    if (!key) key = globalThis.crypto.getRandomValues(new Uint8Array(24))
     if (!(key instanceof Buffer)) key = Buffer.from(key)
 
     // Ciphertext uploading only works if is `uploadCiphertext` is set to true
@@ -592,7 +591,7 @@ class MutableFile extends File {
     let shareKey = formatKey(options.key)
 
     if (!shareKey) {
-      shareKey = secureRandom(16)
+      shareKey = globalThis.crypto.getRandomValues(new Uint8Array(16))
     }
 
     if (!(shareKey instanceof Buffer)) {

--- a/lib/storage.mjs
+++ b/lib/storage.mjs
@@ -74,29 +74,29 @@ class Storage extends EventEmitter {
     // MEGA lower cases email addresses (issue #40)
     this.email = this.options.email.toLowerCase()
 
-    const handleV1Account = (cb) => {
+    const handleV1Account = () => {
       const pw = prepareKey(Buffer.from(this.options.password))
 
       const aes = new AES(pw)
       const uh = e64(aes.stringhash(Buffer.from(this.email)))
       const request = { a: 'us', user: this.email, uh }
-      finishLogin(request, aes, cb)
+      finishLogin(request, aes)
     }
 
-    const handleV2Account = (info, cb) => {
+    const handleV2Account = (info) => {
       prepareKeyV2(Buffer.from(this.options.password), info, (err, result) => {
         if (err) return cb(err)
 
         const aes = new AES(result.slice(0, 16))
         const uh = e64(result.slice(16))
         const request = { a: 'us', user: this.email, uh }
-        finishLogin(request, aes, cb)
+        finishLogin(request, aes)
       })
     }
 
-    const finishLogin = (request, aes, cb) => {
+    const finishLogin = (request, aes) => {
       // after generating the AES key the password isn't needed anymore
-      // delete it to reduce the possibility of someone leaking it
+      // delete it to reduce the possibility of something leaking it
       delete this.options.password
 
       if (this.options.secondFactorCode) {
@@ -125,8 +125,8 @@ class Storage extends EventEmitter {
 
     this.api.request({ a: 'us0', user: this.email }, (err, response) => {
       if (err) return cb(err)
-      if (response.v === 1) return handleV1Account(cb)
-      if (response.v === 2) return handleV2Account(response, cb)
+      if (response.v === 1) return handleV1Account()
+      if (response.v === 2) return handleV2Account(response)
       cb(Error('Account version not supported'))
     })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "abort-controller": "^3.0.0",
         "pumpify": "^2.0.1",
-        "secure-random": "^1.1.2",
         "stream-skip": "^1.0.3"
       },
       "devDependencies": {
@@ -1773,9 +1772,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4377,12 +4376,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -5348,11 +5347,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/secure-random": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/secure-random/-/secure-random-1.1.2.tgz",
-      "integrity": "sha512-H2bdSKERKdBV1SwoqYm6C0y+9EA94v6SUBOWO8kDndc4NoUih7Dv6Tsgma7zO1lv27wIvjlD0ZpMQk7um5dheQ=="
     },
     "node_modules/semver": {
       "version": "7.6.0",
@@ -7756,9 +7750,9 @@
       "dev": true
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -9609,12 +9603,12 @@
       }
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "dependencies": {
@@ -10273,11 +10267,6 @@
         "es-errors": "^1.3.0",
         "is-regex": "^1.1.4"
       }
-    },
-    "secure-random": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/secure-random/-/secure-random-1.1.2.tgz",
-      "integrity": "sha512-H2bdSKERKdBV1SwoqYm6C0y+9EA94v6SUBOWO8kDndc4NoUih7Dv6Tsgma7zO1lv27wIvjlD0ZpMQk7um5dheQ=="
     },
     "semver": {
       "version": "7.6.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
   "dependencies": {
     "abort-controller": "^3.0.0",
     "pumpify": "^2.0.1",
-    "secure-random": "^1.1.2",
     "stream-skip": "^1.0.3"
   },
   "devDependencies": {

--- a/test/helpers/ava-deno.mjs
+++ b/test/helpers/ava-deno.mjs
@@ -1,8 +1,8 @@
 // Ava compatibility layer for Deno
 /* global Deno */
 
-import { assert, assertEquals, assertStrictEquals, assertThrows } from 'https://deno.land/std@0.122.0/testing/asserts.ts'
-import { Buffer } from 'https://cdn.deno.land/std/versions/0.122.0/raw/node/buffer.ts'
+import { assert, assertEquals, assertStrictEquals, assertThrows } from 'jsr:@std/assert'
+import { Buffer } from 'node:buffer'
 
 const testContext = {
   assert,
@@ -37,5 +37,5 @@ test.skip = test.serial.skip = (name, fn, denoOpts = {}) => {
   })
 }
 
-window.Buffer = Buffer
+globalThis.Buffer = Buffer
 export default test

--- a/test/helpers/test-runner.mjs
+++ b/test/helpers/test-runner.mjs
@@ -81,7 +81,7 @@ if (testedPlatform === 'node') {
       'process.env.PACKAGE_VERSION': JSON.stringify(packageJson.version),
       'process.env.MEGA_MOCK_URL': JSON.stringify(null),
       'process.version': '""',
-      global: 'window'
+      global: 'globalThis'
     },
     inject: ['./browser/process-shim.mjs'],
     plugins: [alias({
@@ -96,7 +96,13 @@ if (testedPlatform === 'node') {
       './crypto/rsa.mjs': require.resolve('../../browser/rsa.mjs'),
       './aes.mjs': require.resolve('../../browser/aes.mjs'),
       stream: require.resolve('readable-stream')
-    })]
+    })],
+    external: [
+      'jsr:@std/crypto/crypto',
+      'jsr:@std/encoding',
+      'jsr:@std/assert',
+      'node:buffer'
+    ]
   })
 }
 

--- a/test/helpers/test-utils-deno.mjs
+++ b/test/helpers/test-utils-deno.mjs
@@ -1,6 +1,6 @@
-import { crypto } from 'https://cdn.deno.land/std/versions/0.122.0/raw/crypto/mod.ts'
-import { Buffer } from 'https://cdn.deno.land/std/versions/0.122.0/raw/node/buffer.ts'
-import { encode as hexEncode } from 'https://cdn.deno.land/std/versions/0.122.0/raw/encoding/hex.ts'
+import { crypto } from 'jsr:@std/crypto/crypto'
+import { encodeHex } from 'jsr:@std/encoding'
+import { Buffer } from 'node:buffer'
 
 export function stream2cb (stream, cb) {
   const chunks = []
@@ -56,5 +56,5 @@ export function testBuffer (size, start = 0, step = 1) {
 
 // Helper for getting hex-sha1 for a buffer.
 export function sha1 (buf) {
-  return new TextDecoder().decode(hexEncode(new Uint8Array(crypto.subtle.digestSync('SHA-1', buf))))
+  return encodeHex(new Uint8Array(crypto.subtle.digestSync('SHA-1', buf)))
 }


### PR DESCRIPTION

# Release v1.3.4

<a name="changeSummary-start"></a>

- #232
- #230

<a name="changeSummary-end"></a>
        
## Changelog

<a name="changelog-start"></a>
### Patch Changes

#### [Remove Node 18 from testing, add Node 22 (@qgustavor)](https://github.com/qgustavor/mega/pull/232)

Users of Node 18 should use `--experimental-global-webcrypto` flag.  Support for it ends in 5 months anyway.
#### [Fix various issues (@qgustavor)](https://github.com/qgustavor/mega/pull/230)

Should fix #226 and #227.
               
<a name="changelog-end"></a>
           
           
        