### PR TITLE
Remove Node 18 from testing, add Node 22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Users of Node 18 should use `--experimental-global-webcrypto` flag. Support for it ends in 5 months anyway.