### PR TITLE
Remove redundant AbortController polyfill

### DIFF
--- a/build.js
+++ b/build.js
@@ -72,7 +72,6 @@ async function doBundle (format) {
     external: format.bundleExternals
       ? []
       : [
-          'abort-controller',
           'agentkeepalive',
           'multistream',
           'node-fetch',
@@ -89,7 +88,6 @@ async function doBundle (format) {
       : [alias({
           http: require.resolve('./browser/noop.mjs'),
           https: require.resolve('./browser/noop.mjs'),
-          'abort-controller': require.resolve('./browser/noop.mjs'),
           'node-fetch': require.resolve('./browser/fetch.mjs'),
           './crypto/rsa.mjs': require.resolve('./browser/rsa.mjs'),
           './aes.mjs': require.resolve('./browser/aes.mjs'),

--- a/lib/abort-controller-polyfill.mjs
+++ b/lib/abort-controller-polyfill.mjs
@@ -1,3 +1,0 @@
-import abortControllerPolyfill from 'abort-controller'
-const abortController = globalThis.AbortController || abortControllerPolyfill
-export default abortController

--- a/lib/api.mjs
+++ b/lib/api.mjs
@@ -1,7 +1,6 @@
 import { EventEmitter } from 'events'
 import { Agent as HttpAgent } from 'http'
 import { Agent as HttpsAgent } from 'https'
-import AbortController from './abort-controller-polyfill.mjs'
 import { createPromise } from './util.mjs'
 
 const MAX_RETRIES = 4

--- a/lib/file.mjs
+++ b/lib/file.mjs
@@ -4,7 +4,6 @@ import { EventEmitter } from 'events'
 import { streamToCb, createPromise } from './util.mjs'
 import { PassThrough } from 'stream'
 import StreamSkip from 'stream-skip'
-import AbortController from './abort-controller-polyfill.mjs'
 
 class File extends EventEmitter {
   constructor (opt) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
-        "abort-controller": "^3.0.0",
         "pumpify": "^2.0.1",
         "stream-skip": "^1.0.3"
       },
@@ -945,6 +944,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -2912,6 +2912,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -7151,6 +7152,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
       "requires": {
         "event-target-shim": "^5.0.0"
       }
@@ -8569,7 +8571,8 @@
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true
     },
     "events": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "provenance": true
   },
   "dependencies": {
-    "abort-controller": "^3.0.0",
     "pumpify": "^2.0.1",
     "stream-skip": "^1.0.3"
   },

--- a/test/helpers/test-runner.mjs
+++ b/test/helpers/test-runner.mjs
@@ -91,7 +91,6 @@ if (testedPlatform === 'node') {
       // The below aliases are copied from build.js
       http: require.resolve('../../browser/noop.mjs'),
       https: require.resolve('../../browser/noop.mjs'),
-      'abort-controller': require.resolve('../../browser/noop.mjs'),
       'node-fetch': require.resolve('../../browser/fetch.mjs'),
       './crypto/rsa.mjs': require.resolve('../../browser/rsa.mjs'),
       './aes.mjs': require.resolve('../../browser/aes.mjs'),

--- a/types/cjs.d.ts
+++ b/types/cjs.d.ts
@@ -4,7 +4,6 @@ import { EventEmitter } from 'events'
 import { Agent as HttpAgent } from 'http'
 import { Agent as HttpsAgent } from 'https'
 
-import AbortController from 'abort-controller'
 import type * as fetch from 'node-fetch'
 
 declare function megajs (options: megajs.StorageOpts, cb?: megajs.errorCb): megajs.Storage


### PR DESCRIPTION
AbortController is supported in all environments, including Node.js, since v14.12, all modern browsers, React Native and all serverless environments ([link](https://runtime-compat.unjs.io)) except Fastly, for which you can load a polyfill in your own project (which is how polyfills are meant to be consumed).

All tests pass.