### PR TITLE
Implement hashcash

### DIFF
--- a/lib/api.mjs
+++ b/lib/api.mjs
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events'
 import { Agent as HttpAgent } from 'http'
 import { Agent as HttpsAgent } from 'https'
 import { createPromise } from './util.mjs'
+import { generateHashcashToken } from './crypto/index.mjs'
 
 const MAX_RETRIES = 4
 const ERRORS = {
@@ -99,11 +100,25 @@ class API extends EventEmitter {
       delete json._querystring
     }
 
+    const headers = { 'Content-Type': 'application/json' }
+    if (typeof json._hashcash === 'string') {
+      headers['X-Hashcash'] = json._hashcash
+      delete json._querystring
+    }
+
     this.fetch(`${this.gateway}cs?${new URLSearchParams(qs)}`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify([json])
-    }).then(handleApiResponse).then(resp => {
+    }).then(async resp => {
+      const hashcashChallenge = resp.headers.get('X-Hashcash')
+      if (hashcashChallenge) {
+        json._hashcash = await generateHashcashToken(hashcashChallenge)
+        // Simulate an EAGAIN response
+        return -3
+      }
+      return handleApiResponse(resp)
+    }).then(resp => {
       if (this.closed && !isLogout) return
       if (!resp) return cb(Error('Empty response'))
 

--- a/lib/crypto/index.mjs
+++ b/lib/crypto/index.mjs
@@ -167,3 +167,33 @@ function constantTimeCompare (bufferA, bufferB) {
 }
 
 export { constantTimeCompare }
+
+export async function generateHashcashToken (challenge) {
+  const [versionStr, easinessStr,, tokenStr] = challenge.split(':')
+  const version = Number(versionStr)
+  if (version !== 1) throw Error('hashcash challenge is not version 1')
+
+  const easiness = Number(easinessStr)
+  const base = ((easiness & 63) << 1) + 1
+  const shifts = (easiness >> 6) * 7 + 3
+  const threshold = base << shifts
+  const token = d64(tokenStr)
+
+  const buffer = Buffer.alloc(4 + 262144 * 48)
+  for (let i = 0; i < 262144; i++) {
+    buffer.set(token, 4 + i * 48)
+  }
+
+  while (true) {
+    const view = new DataView(await globalThis.crypto.subtle.digest('SHA-256', buffer))
+    if (view.getUint32(0) <= threshold) {
+      return `1:${tokenStr}:${e64(buffer.slice(0, 4))}`
+    }
+
+    let j = 0
+    while (true) {
+      buffer[j]++
+      if (buffer[j++]) break
+    }
+  }
+}


### PR DESCRIPTION
The implementation is largely the same as official's web client. I checked it by uploading a file (which was previously failing due to the missing hashcash implementation) and should fix #239. I'm certain a more optimized function can be written. Here are some ideas:

- While I benchmarked SHA-256 implementations in Deno, maybe there are faster implementations I have not considered that are faster than Web Crypto.
- Due to how the "threshold" variable is constructed using bit-shifts, comparing a 32 bit integer might be overkill. But, then, there were cases that you had to compare 3 bytes instead of 4 bytes and, without a benchmark, that's hard to argue that it would improve performance a lot.
- Maybe implementing all logic in WASM could be a solution.

Also, should we write tests for it? If so, how?