### PR TITLE
Fix getShouldAvoidUA

### DIFF
--- a/lib/api.mjs
+++ b/lib/api.mjs
@@ -227,20 +227,12 @@ class API extends EventEmitter {
   }
 
   static getShouldAvoidUA () {
-    // It's not possible to detect when a browser fails CORS requests by defining an user-agent
-    // using feature detection, so the alternatives were using user-agent detection
-    // (which is not ideal because might not catch Firefox forks) or hacks.
-
-    // This library uses hacks.
-    // Those were found using BrowserStack and the following tests: https://codepen.io/qgustavor/pen/JjqqBPp
-
-    let headersErr
-    try {
-      globalThis.Headers()
-    } catch (err) {
-      headersErr = err.message
-    }
-    return !((globalThis.fetch + '').length === 38 && headersErr.includes('Headers'))
+    // The only case where we need to avoid setting an user-agent is on browsers
+    // as it would lead to CORS issues as user-agent isn't a whitelisted header
+    // (as it's not included on Access-Control-Allow-Headers from MEGA responses)
+    // but the only browser that causes issues from that is Firefox as it is the
+    // only one that allows JavaScript overriding the user-agent.
+    return !!globalThis.navigator
   }
 }
 


### PR DESCRIPTION
The old implementation broke. I guess it was due a Firefox update. Fixes #252.