### PR TITLE
Release - v1.4.0

### DIFF
--- a/lib/file.mjs
+++ b/lib/file.mjs
@@ -52,22 +52,28 @@ class File extends EventEmitter {
 
     if (!aes || !opt.k) return
 
-    const parts = opt.k.split(':')
-    this.key = formatKey(parts[parts.length - 1])
+    // HACK: The correct key for shared folder is the one which parts[0] === folder.h
+    // but we can just try every single key alternative
+    const keyAlternatives = opt.k.split('/').map(e => e.split(':'))
+    for (const parts of keyAlternatives) {
+      this.key = formatKey(parts[parts.length - 1])
 
-    if (this.key.length <= 32) {
-      // Regular AES-ECB encrypted key
-      aes.decryptECB(this.key)
-    } else if (this.storage) {
-      // RSA encrypted key
-      this.key = this.storage.decryptRsaKey(this.key).slice(0, this.directory ? 16 : 32)
-    } else {
-      // Can't decrypt a RSA key without a storage
-      this.key = null
-    }
+      if (this.key.length <= 32) {
+        // Regular AES-ECB encrypted key
+        aes.decryptECB(this.key)
+      } else if (this.storage) {
+        // RSA encrypted key
+        this.key = this.storage.decryptRsaKey(this.key).slice(0, this.directory ? 16 : 32)
+      } else {
+        // Can't decrypt a RSA key without a storage
+        this.key = null
+      }
 
-    if (opt.a) {
-      this.decryptAttributes(opt.a)
+      // HACK use the decryption of attributes as a marker for the correct key
+      if (opt.a) {
+        const gotSuccess = this.decryptAttributes(opt.a)
+        if (gotSuccess) break
+      }
     }
   }
 
@@ -79,7 +85,10 @@ class File extends EventEmitter {
     const unpackedAttribtes = File.unpackAttributes(at)
     if (unpackedAttribtes) {
       this.parseAttributes(unpackedAttribtes)
+      return true
     }
+
+    return false
   }
 
   parseAttributes (at) {
@@ -117,7 +126,7 @@ class File extends EventEmitter {
         const folder = nodes.find(node => node.k &&
           // support multiple k definitions
           node.k.split('/').some(part =>
-            // the root folder is the one which "n" equals the first part of "k"
+            // the root folder is the one which "h" equals the first part of "k"
             node.h === part.split(':')[0]
           )
         )

--- a/lib/file.mjs
+++ b/lib/file.mjs
@@ -115,8 +115,11 @@ class File extends EventEmitter {
         const filesMap = Object.create(null)
         const nodes = response.f
         const folder = nodes.find(node => node.k &&
-          // the root folder is the one which "n" equals the first part of "k"
-          node.h === node.k.split(':')[0]
+          // support multiple k definitions
+          node.k.split('/').some(part =>
+            // the root folder is the one which "n" equals the first part of "k"
+            node.h === part.split(':')[0]
+          )
         )
         const aes = this.key ? new AES(this.key) : null
         this.nodeId = folder.h

--- a/lib/mutable-file.mjs
+++ b/lib/mutable-file.mjs
@@ -503,6 +503,41 @@ class MutableFile extends File {
 
     return this.api.request(request, cb)
   }
+  copyTo (target, cb) {
+    if (typeof target === 'string') {
+      target = this.storage.files[target]
+    }
+
+    if (!(target instanceof File)) {
+      throw Error('target must be a folder or a nodeId')
+    }
+    
+    const attributes = _MutableFile.packAttributes(this.attributes)
+    getCipher(this.key).encryptCBC(attributes)
+    
+    const request = {
+        a: "p",
+        sm: 1,
+        v: 3,
+        t: target.nodeId ? target.nodeId : target,
+        n: [{
+          k: e64(this.storage.aes.encryptECB(this.key)),
+          a: e64(attributes),
+          h: this.nodeId,
+          t: 0
+        }]
+      }
+    
+    const shares = getShares(this.storage.shareKeys, target)
+    if (shares.length > 0) {
+      request.cr = makeCryptoRequest(this.storage,  [{
+        nodeId: this.nodeId,
+        key: this.key
+      }], shares);
+    }
+    
+    return this.api.request(request, cb)
+  }
 
   setAttributes (attributes, originalCb) {
     const [cb, promise] = createPromise(originalCb)

--- a/lib/mutable-file.mjs
+++ b/lib/mutable-file.mjs
@@ -503,6 +503,7 @@ class MutableFile extends File {
 
     return this.api.request(request, cb)
   }
+
   copyTo (target, cb) {
     if (typeof target === 'string') {
       target = this.storage.files[target]
@@ -511,31 +512,31 @@ class MutableFile extends File {
     if (!(target instanceof File)) {
       throw Error('target must be a folder or a nodeId')
     }
-    
-    const attributes = _MutableFile.packAttributes(this.attributes)
+
+    const attributes = MutableFile.packAttributes(this.attributes)
     getCipher(this.key).encryptCBC(attributes)
-    
+
     const request = {
-        a: "p",
-        sm: 1,
-        v: 3,
-        t: target.nodeId ? target.nodeId : target,
-        n: [{
-          k: e64(this.storage.aes.encryptECB(this.key)),
-          a: e64(attributes),
-          h: this.nodeId,
-          t: 0
-        }]
-      }
-    
+      a: 'p',
+      sm: 1,
+      v: 3,
+      t: target.nodeId,
+      n: [{
+        k: e64(this.storage.aes.encryptECB(this.key)),
+        a: e64(attributes),
+        h: this.nodeId,
+        t: 0
+      }]
+    }
+
     const shares = getShares(this.storage.shareKeys, target)
     if (shares.length > 0) {
-      request.cr = makeCryptoRequest(this.storage,  [{
+      request.cr = makeCryptoRequest(this.storage, [{
         nodeId: this.nodeId,
         key: this.key
-      }], shares);
+      }], shares)
     }
-    
+
     return this.api.request(request, cb)
   }
 

--- a/test/helpers/test-runner.mjs
+++ b/test/helpers/test-runner.mjs
@@ -162,6 +162,7 @@ if (testedPlatform === 'node') {
   await new Promise(resolve => {
     const subprocess = cp.spawn('deno', [
       'test',
+      '--no-check',
       '--allow-env=MEGA_MOCK_URL',
       '--allow-net=' + gateway.slice(7, -1),
       ...extraArguments

--- a/types/cjs.d.ts
+++ b/types/cjs.d.ts
@@ -124,6 +124,7 @@ declare namespace megajs {
     setAttributes (attributes: JSON, cb?: noop): Promise<void>
     delete (permanent?: boolean, cb?: (error: err, data?: any) => void): Promise<void>
     moveTo (target: File | string, cb?: (error: err, data?: any) => void): Promise<void>
+    copyTo (target: File | string, cb?: (error: err, data?: any) => void): Promise<void>
     upload (opts: uploadOpts | string, source?: BufferString, cb?: uploadCb): Writable
     mkdir (opts: mkdirOpts | string, cb?: (error: err, file: MutableFile) => void): Promise<MutableFile>
     navigate (query: string | string[]): MutableFile | undefined

--- a/types/es.d.ts
+++ b/types/es.d.ts
@@ -120,6 +120,7 @@ declare class MutableFile extends File {
   setAttributes (attributes: JSON, cb?: noop): Promise<void>
   delete (permanent?: boolean, cb?: (error: err, data?: any) => void): Promise<void>
   moveTo (target: File | string, cb?: (error: err, data?: any) => void): Promise<void>
+  copyTo (target: File | string, cb?: (error: err, data?: any) => void): Promise<void>
   upload (opts: uploadOpts | string, source?: BufferString, cb?: uploadCb): Writable
   mkdir (opts: mkdirOpts | string, cb?: (error: err, file: MutableFile) => void): Promise<MutableFile>
   navigate (query: string | string[]): MutableFile | undefined


### PR DESCRIPTION
# Release v1.4.0

<a name="changeSummary-start"></a>

- #266
- #260
- #259
- #257

<a name="changeSummary-end"></a>
        
## Changelog

<a name="changelog-start"></a>
### Minor Changes

#### [Implement copyTo (@qgustavor)](https://github.com/qgustavor/mega/pull/257)

Allows copying files.

### Patch Changes

#### [Support multiple node.k definitions (@qgustavor)](https://github.com/qgustavor/mega/pull/266)

Fixes issues related to nodes which have multiple key definitions and, due to that, weren't decrypting.
               
<a name="changelog-end"></a>
           
           
           
           
           
           
        