### PR TITLE
Fixes for copyTo implementation

### DIFF
--- a/lib/mutable-file.mjs
+++ b/lib/mutable-file.mjs
@@ -503,6 +503,7 @@ class MutableFile extends File {
 
     return this.api.request(request, cb)
   }
+
   copyTo (target, cb) {
     if (typeof target === 'string') {
       target = this.storage.files[target]
@@ -511,31 +512,31 @@ class MutableFile extends File {
     if (!(target instanceof File)) {
       throw Error('target must be a folder or a nodeId')
     }
-    
-    const attributes = _MutableFile.packAttributes(this.attributes)
+
+    const attributes = MutableFile.packAttributes(this.attributes)
     getCipher(this.key).encryptCBC(attributes)
-    
+
     const request = {
-        a: "p",
-        sm: 1,
-        v: 3,
-        t: target.nodeId ? target.nodeId : target,
-        n: [{
-          k: e64(this.storage.aes.encryptECB(this.key)),
-          a: e64(attributes),
-          h: this.nodeId,
-          t: 0
-        }]
-      }
-    
+      a: 'p',
+      sm: 1,
+      v: 3,
+      t: target.nodeId,
+      n: [{
+        k: e64(this.storage.aes.encryptECB(this.key)),
+        a: e64(attributes),
+        h: this.nodeId,
+        t: 0
+      }]
+    }
+
     const shares = getShares(this.storage.shareKeys, target)
     if (shares.length > 0) {
-      request.cr = makeCryptoRequest(this.storage,  [{
+      request.cr = makeCryptoRequest(this.storage, [{
         nodeId: this.nodeId,
         key: this.key
-      }], shares);
+      }], shares)
     }
-    
+
     return this.api.request(request, cb)
   }
 


### PR DESCRIPTION
Linting fixes (like double quotes and wrong whitespace) and also simplified the `target.nodeId ? target.nodeId : target` ternary because, if target is a `File`, then it doesn't make sense stringifying it in the request, if `nodeId` isn't defined it's better to fail.