### PR TITLE
Attempt 1 to fix Deno tests

### DIFF
--- a/test/helpers/test-runner.mjs
+++ b/test/helpers/test-runner.mjs
@@ -162,6 +162,7 @@ if (testedPlatform === 'node') {
   await new Promise(resolve => {
     const subprocess = cp.spawn('deno', [
       'test',
+      '--no-check',
       '--allow-env=MEGA_MOCK_URL',
       '--allow-net=' + gateway.slice(7, -1),
       ...extraArguments


### PR DESCRIPTION
Added --no-check because of this:

   info: The program failed type-checking, but it still might work correctly.
  hint: Re-run with --no-check to skip type-checking.

It should not type check the tests! Why is it doing that? It works on my machine!