### PR TITLE
Attempt fixing #240

### DIFF
--- a/lib/file.mjs
+++ b/lib/file.mjs
@@ -422,7 +422,8 @@ class File extends EventEmitter {
       }
     }
 
-    let url = `https://mega.nz/${this.directory ? 'folder' : 'file'}/${this.downloadId}`
+    const downloadId = Array.isArray(this.downloadId) ? this.downloadId[1] : this.downloadId
+    let url = `https://mega.nz/${this.directory ? 'folder' : 'file'}/${downloadId}`
     if (!options.noKey && this.key) url += `#${e64(this.key)}`
     if (!options.noKey && this.loadedFile) {
       // TODO: check if the loaded file is, in fact, a folder

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "ava": "^6.1.2",
         "buffer": "^6.0.3",
         "core-js": "^3.36.1",
+        "cross-spawn": "^7.0.6",
         "esbuild": "^0.25.0",
         "esbuild-plugin-alias": "^0.2.1",
         "events": "^3.3.0",
@@ -1846,6 +1847,7 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "ava": "^6.1.2",
     "buffer": "^6.0.3",
     "core-js": "^3.36.1",
+    "cross-spawn": "^7.0.6",
     "esbuild": "^0.25.0",
     "esbuild-plugin-alias": "^0.2.1",
     "events": "^3.3.0",

--- a/test/helpers/test-runner.mjs
+++ b/test/helpers/test-runner.mjs
@@ -1,10 +1,10 @@
 // This script handles test preparation, running in Node and Deno then cleanup
 import alias from 'esbuild-plugin-alias'
 import { fileURLToPath } from 'node:url'
-import cp from 'node:child_process'
 import fs from 'node:fs/promises'
 import megamock from 'mega-mock'
 import crypto from 'node:crypto'
+import spawn from 'cross-spawn'
 import esbuild from 'esbuild'
 import tmp from 'tmp-promise'
 import path from 'node:path'
@@ -131,14 +131,13 @@ let wasFailed = false
 // Run tests
 if (testedPlatform === 'node') {
   await new Promise(resolve => {
-    const subprocess = cp.spawn('npx', [
+    const subprocess = spawn('npx', [
       'ava',
       '--',
       path.join(buildDir, '*.js'),
       ...extraArguments
     ], {
       stdio: 'inherit',
-      shell: os.platform() === 'win32',
       env: {
         ...process.env,
         MEGA_MOCK_URL: gateway
@@ -160,7 +159,7 @@ if (testedPlatform === 'node') {
   })
 } else {
   await new Promise(resolve => {
-    const subprocess = cp.spawn('deno', [
+    const subprocess = spawn('deno', [
       'test',
       '--no-check',
       '--allow-env=MEGA_MOCK_URL',
@@ -169,7 +168,6 @@ if (testedPlatform === 'node') {
     ], {
       cwd: buildDir,
       stdio: 'inherit',
-      shell: os.platform() === 'win32',
       env: {
         ...process.env,
         MEGA_MOCK_URL: gateway

--- a/test/storage.test.mjs
+++ b/test/storage.test.mjs
@@ -305,6 +305,18 @@ test.serial('Should upload files in folders in shared folders', t => {
   })
 })
 
+// See issue #240
+// SKIPPED: depends on fixing mega-mock shared file key handling
+test.serial.skip('.link() should work in files in shared folders', async t => {
+  const folder = File.fromURL('https://mega.nz/folder/AAAAAAAG#AAAAAAAAAAAAAAAAAAAAAA')
+  folder.api = storage.api
+  await folder.loadAttributes()
+
+  const file = folder.children[0]
+  const link = await file.link()
+  t.is(link, 'https://mega.nz/folder/AAAAAAAG#AAAAAAAAAAAAAAAAAAAAAA')
+})
+
 // TODO implement test for download files shared in folders
 // Depends on fixing mega-mock shared file key handling
 


### PR DESCRIPTION
1. Fix .downloadId handling
2. Attempt adding a unit test for that
3. Realize mega-mock doesn't handle sharing yet and have to skip the test
4. Fix a warning in the tests by replacing shell: true with cross-spawn